### PR TITLE
Add ability to autofocus form elements by default

### DIFF
--- a/easy-overlay.js
+++ b/easy-overlay.js
@@ -194,6 +194,9 @@ var easyOverlay=(function(){
 	}
 
 	function overlayPrepare($content,options,self){
+		if(options.autofocus === true) {
+			autofocus($content);
+		}
 		if (cls.overlayCallAll){
 			cls.overlayCallAll.call(cls,$content);
 		}
@@ -218,6 +221,15 @@ var easyOverlay=(function(){
 		if (options.foreground){
 			foreground($(options.foreground),$content);
 		}
+	}
+
+	function autofocus($content) {
+		$content.find('form input, form textarea').each(function() {
+			if($(this).attr('type') != 'hidden' && $(this).val() == '') {
+				$(this).focus();
+				return false;
+			}
+		});
 	}
 
 // cls
@@ -284,6 +296,7 @@ var easyOverlay=(function(){
 				};
 			}
 			count++;
+			options.autofocus = options.autofocus === undefined ? true : options.autofocus;
 			options.css = options.css===false ? {} : $.extend(css.content, options.css);
 			options.css['z-index'] = 50 + (count*5)+1;
 


### PR DESCRIPTION
By default easyOverlay will try and find first visible and not empty
form element and add focus to it. This can be overriden in overlayCall
or by passing autofocus = false option.